### PR TITLE
Prevent overwriting outfile and improve portability

### DIFF
--- a/mfhds-fromtsv
+++ b/mfhds-fromtsv
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 bibsonly="no"
 loc_subfield="b"

--- a/mfhds-fromtsv
+++ b/mfhds-fromtsv
@@ -250,7 +250,7 @@ function build_mfhd() {
 	leader = sprintf("%05d", record_length)""leader1""base_data_address""leader2
 
 	if (processed[holdId] != 1){ 
-		print leader""directory""record_content > OUTFILE
+		print leader""directory""record_content >> OUTFILE
 		processed[holdId] = 1
 		created = created + 1
 	}
@@ -512,6 +512,14 @@ ENDOFAWK
 echo -e "${awkscript}" > tmp_mfhdsfromtsv
 chmod 700 tmp_mfhdsfromtsv
 
-awk -v ORS=$'\x1d' -v RS='\n' -v OFS=$'\x1e' -v FS='\t' -v SFS=$'\x1f' -v OUTFILE="${outfile}" -v BIBSONLY=${bibsonly} -v LOCATION="${location}" -v LOC_SUBFIELD=${loc_subfield} -b -f tmp_mfhdsfromtsv "${infile}"
+if [[ -z "${outfile}" ]]; then
+    outfile="mfhds_output.mrc"
+fi
+> "${outfile}"
+
+for infile in "${infiles[@]}"; do
+	echo "Processing: ${infile}"
+	awk -v ORS=$'\x1d' -v RS='\n' -v OFS=$'\x1e' -v FS='\t' -v SFS=$'\x1f' -v OUTFILE="${outfile}" -v BIBSONLY=${bibsonly} -v LOCATION="${location}" -v LOC_SUBFIELD=${loc_subfield} -b -f tmp_mfhdsfromtsv "${infile}"
+done
 
 rm -f tmp_mfhdsfromtsv


### PR DESCRIPTION
Ensure the `mfhds-fromtsv` script does not overwrite the output file when using wildcards and multiple files. Update the shebang for better portability across different environments.